### PR TITLE
security: implement input validation for API routes (#5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "stripe": "^20.3.0",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getStripe, PLANS } from "@/lib/stripe";
 import { siteConfig } from "@/config/site";
+import { z } from "zod";
+
+const checkoutSchema = z.object({
+  plan: z.enum(["pro"]),
+});
 
 export async function POST(request: Request) {
   try {
@@ -13,6 +18,27 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    // Validate input
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid JSON body" },
+        { status: 400 }
+      );
+    }
+
+    const result = checkoutSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json(
+        { error: "Invalid request data", details: result.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const { plan } = result.data;
 
     // Get or create Stripe customer
     const { data: profile } = await supabase
@@ -36,10 +62,10 @@ export async function POST(request: Request) {
         .eq("id", user.id);
     }
 
-    const priceId = PLANS.pro.priceId;
+    const priceId = PLANS[plan].priceId;
     if (!priceId) {
       return NextResponse.json(
-        { error: "Pro plan price not configured" },
+        { error: "Plan price not configured" },
         { status: 500 }
       );
     }


### PR DESCRIPTION
## Summary
Add Zod input validation to the Stripe checkout API route to prevent invalid/malicious requests.

## Changes
- **`src/app/api/stripe/checkout/route.ts`**: 
  - Added `checkoutSchema` (Zod) requiring `{plan: "pro"}`
  - Safe JSON parsing with 400 error on invalid body
  - Schema validation with structured error response
  - Dynamic plan → priceId lookup (instead of hardcoded `PLANS.pro`)
- Verified portal route (no input needed) and webhook route (Stripe signature verification already present)

## Why
The checkout endpoint accepted any/no input and always charged for Pro. With validation, invalid requests fail fast with clear 400 errors, and the plan selection is validated before hitting Stripe.

Fixes #5