### PR TITLE
fix: validate Stripe API version matches package (#1)

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -7,7 +7,7 @@ let _stripe: Stripe | null = null;
 export function getStripe(): Stripe {
   if (!_stripe) {
     _stripe = new Stripe(env.STRIPE_SECRET_KEY, {
-      apiVersion: "2026-01-28.clover",
+      apiVersion: "2026-01-28.clover", // Validated: matches stripe@20.3.0 type definition
       typescript: true,
     });
   }


### PR DESCRIPTION
## Summary
Verified that the Stripe API version `2026-01-28.clover` is correct and matches the installed `stripe@20.3.0` package's TypeScript definitions. Added a clarifying comment to prevent future confusion.

## Changes
- Added documentation comment in `src/lib/stripe.ts` confirming the API version is valid

## Verification
- Checked `node_modules/stripe/types/apiVersion.d.ts` — exports this exact version string
- Intentionally changing the version causes TypeScript errors — confirming type safety

Fixes #1