### PR TITLE
feat: add dashboard loading and error states (#6)

### DIFF
--- a/src/app/(dashboard)/dashboard/error.tsx
+++ b/src/app/(dashboard)/dashboard/error.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center">
+      <Card className="w-[400px]">
+        <CardHeader>
+          <CardTitle className="text-destructive">Something went wrong!</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            We encountered an error while loading your dashboard. Please try again.
+          </p>
+          {process.env.NODE_ENV === 'development' && (
+            <div className="mt-4 max-h-[200px] overflow-auto rounded bg-muted p-2 text-xs font-mono">
+              {error.message}
+            </div>
+          )}
+        </CardContent>
+        <CardFooter>
+          <Button onClick={() => reset()} className="w-full">
+            Try again
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/loading.tsx
+++ b/src/app/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function DashboardLoading() {
+  return (
+    <div>
+      <Skeleton className="h-8 w-[200px]" />
+      <Skeleton className="mt-2 h-4 w-[300px]" />
+
+      {/* Stats Grid Skeleton */}
+      <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {[...Array(3)].map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">
+                <Skeleton className="h-4 w-[100px]" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-[60px] mb-1" />
+              <Skeleton className="h-3 w-[120px]" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Empty State Skeleton */}
+      <div className="mt-12 rounded-xl border-2 border-dashed border-gray-300 p-12 text-center flex flex-col items-center">
+        <Skeleton className="h-6 w-[200px] mb-2" />
+        <Skeleton className="h-4 w-[300px] mb-6" />
+        <Skeleton className="h-10 w-[120px]" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import { cn } from '@/lib/utils';
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-muted', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };


### PR DESCRIPTION
## Summary
Adds proper loading and error UI for the dashboard route.

## Changes
- **`src/components/ui/skeleton.tsx`**: Reusable Skeleton component with `animate-pulse`
- **`src/app/(dashboard)/dashboard/loading.tsx`**: Skeleton UI mirroring the dashboard layout (stats grid + empty state)
- **`src/app/(dashboard)/dashboard/error.tsx`**: Client error boundary with "Try again" button. Shows error details in dev mode.

## Verification
- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm test` ✅

Fixes #6