### PR TITLE
feat: wire up create project button with coming-soon toast (#9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "sonner": "^2.0.7",
     "stripe": "^20.3.0",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       stripe:
         specifier: ^20.3.0
         version: 20.3.0(@types/node@20.19.30)
@@ -2527,6 +2530,12 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5354,6 +5363,11 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CreateProjectButton } from "@/components/create-project-button";
 
 export default async function DashboardPage() {
   const supabase = await createClient();
@@ -28,7 +28,7 @@ export default async function DashboardPage() {
         <p className="mt-2 text-sm text-gray-600">
           Get started by creating your first project.
         </p>
-        <Button className="mt-6">Create Project</Button>
+        <CreateProjectButton className="mt-6" />
       </div>
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { Toaster } from "sonner";
 import { siteConfig } from "@/config/site";
 import "./globals.css";
 
@@ -32,7 +33,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.className} antialiased`}>{children}</body>
+      <body className={`${inter.className} antialiased`}>
+        {children}
+        <Toaster />
+      </body>
     </html>
   );
 }

--- a/src/components/create-project-button.tsx
+++ b/src/components/create-project-button.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button, type ButtonProps } from "@/components/ui/button";
+
+export function CreateProjectButton({ className, ...props }: ButtonProps) {
+  return (
+    <Button
+      className={className}
+      onClick={() =>
+        toast("🚧 Coming soon!", {
+          description: "Project creation is under development.",
+        })
+      }
+      {...props}
+    >
+      <Plus className="size-4" />
+      Create Project
+    </Button>
+  );
+}


### PR DESCRIPTION
Fixes #9

## Changes
- Added `sonner` toast library (standard for shadcn/ui, reusable app-wide)
- Added `<Toaster />` provider to root layout
- Created `CreateProjectButton` client component with Plus icon + toast notification
- Replaced dead `<Button>` on dashboard with functional `<CreateProjectButton />`

Clicking 'Create Project' now shows a friendly '🚧 Coming soon!' toast instead of doing nothing.

## Verification
- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm test` ✅