### PR TITLE
refactor: migrate middleware to proxy convention (#8)

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
 
-export async function middleware(request: NextRequest) {
+export default async function proxy(request: NextRequest) {
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## Summary
Migrate `src/middleware.ts` to `src/proxy.ts` to align with Next.js 16 conventions.

### Changes
- Renamed `src/middleware.ts` → `src/proxy.ts`
- Changed export: `export async function middleware` → `export default async function proxy`

### Why
Next.js 16 deprecated the `middleware` file convention in favor of `proxy`. Build was emitting:
```
⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.
```

### Verification
- `pnpm build` ✅ (deprecation warning gone)
- `pnpm lint` ✅

Fixes #8