### PR TITLE
feat: connect dashboard & settings to real profile data (#20)

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -8,6 +8,16 @@ export default async function DashboardPage() {
     data: { user },
   } = await supabase.auth.getUser();
 
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("id", user?.id)
+    .single();
+
+  const planLabel = profile?.plan
+    ? profile.plan.charAt(0).toUpperCase() + profile.plan.slice(1)
+    : "Free";
+
   return (
     <div>
       <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
@@ -17,9 +27,10 @@ export default async function DashboardPage() {
 
       {/* Stats Grid */}
       <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {/* TODO: Connect to real projects count when table exists */}
         <StatCard title="Projects" value="0" description="Active projects" />
         <StatCard title="Usage" value="0%" description="Of your plan limit" />
-        <StatCard title="Plan" value="Free" description="Upgrade anytime" />
+        <StatCard title="Plan" value={planLabel} description="Upgrade anytime" />
       </div>
 
       {/* Empty State */}

--- a/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -9,6 +9,16 @@ export default async function SettingsPage() {
 
   if (!user) redirect("/login");
 
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("id", user.id)
+    .single();
+
+  const planLabel = profile?.plan
+    ? profile.plan.charAt(0).toUpperCase() + profile.plan.slice(1)
+    : "Free";
+
   return (
     <div>
       <h1 className="text-2xl font-bold text-gray-900">Settings</h1>
@@ -41,17 +51,28 @@ export default async function SettingsPage() {
         <div className="mt-4">
           <div className="flex items-center justify-between">
             <div>
-              <p className="font-medium text-gray-900">Free Plan</p>
+              <p className="font-medium text-gray-900">{planLabel} Plan</p>
               <p className="text-sm text-gray-600">
-                Basic features included.
+                {profile?.plan === "pro"
+                  ? "You have access to all features."
+                  : "Basic features included."}
               </p>
             </div>
-            <a
-              href="/pricing"
-              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-            >
-              Upgrade to Pro
-            </a>
+            {profile?.plan !== "pro" && (
+              <a
+                href="/pricing"
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Upgrade to Pro
+              </a>
+            )}
+            {profile?.plan === "pro" && (
+               <button
+               className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+             >
+               Manage Subscription
+             </button>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #20

## Changes
- **Dashboard**: Fetches user profile from `profiles` table, displays real plan name (Free/Pro) instead of hardcoded 'Free'
- **Settings**: Shows actual subscription plan with conditional Upgrade/Manage buttons
- Both pages have graceful null fallbacks (defaults to 'Free' if profile missing)

## Files Changed
- `src/app/(dashboard)/dashboard/page.tsx` — profile fetch + dynamic plan StatCard
- `src/app/(dashboard)/dashboard/settings/page.tsx` — profile fetch + conditional subscription UI

Projects count remains '0' with TODO comment (waiting for projects table in #21).