### PR TITLE
feat: add projects table schema with RLS (#21)

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -46,6 +46,32 @@ export interface Database {
           updated_at?: string;
         };
       };
+      projects: {
+        Row: {
+          id: string;
+          name: string;
+          description: string | null;
+          user_id: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          name: string;
+          description?: string | null;
+          user_id: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          name?: string;
+          description?: string | null;
+          user_id?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
     };
     Views: Record<string, never>;
     Functions: Record<string, never>;

--- a/supabase/migrations/00002_projects.sql
+++ b/supabase/migrations/00002_projects.sql
@@ -1,0 +1,45 @@
+-- Create projects table
+CREATE TABLE IF NOT EXISTS public.projects (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Enable RLS
+ALTER TABLE public.projects ENABLE ROW LEVEL SECURITY;
+
+-- Users can view their own projects
+CREATE POLICY "Users can view own projects"
+  ON public.projects FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Users can create their own projects
+CREATE POLICY "Users can create own projects"
+  ON public.projects FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Users can update their own projects
+CREATE POLICY "Users can update own projects"
+  ON public.projects FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- Users can delete their own projects
+CREATE POLICY "Users can delete own projects"
+  ON public.projects FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Auto-update updated_at
+CREATE OR REPLACE FUNCTION public.handle_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER on_projects_updated
+  BEFORE UPDATE ON public.projects
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();


### PR DESCRIPTION
Closes #21

## Changes
- **Migration** (`supabase/migrations/00002_projects.sql`):
  - `projects` table with UUID pk, name, description, user_id (FK → auth.users, CASCADE delete)
  - RLS enabled with 4 user-scoped policies (SELECT, INSERT, UPDATE, DELETE)
  - Auto-update trigger for `updated_at`
- **Types** (`src/types/database.ts`):
  - Added `projects` table types (Row, Insert, Update) matching the schema

This unblocks #22 (Project Creation UI).