### PR TITLE
feat: implement account deletion with confirmation (#23)

### DIFF
--- a/src/app/(dashboard)/dashboard/settings/actions.ts
+++ b/src/app/(dashboard)/dashboard/settings/actions.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { createAdminClient, createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+
+export async function deleteAccount() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("Unauthorized");
+  }
+
+  const adminClient = createAdminClient();
+  const { error } = await adminClient.auth.admin.deleteUser(user.id);
+
+  if (error) {
+    console.error("Error deleting user:", error);
+    throw new Error("Failed to delete account");
+  }
+
+  redirect("/login");
+}

--- a/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { DeleteAccountButton } from "@/components/delete-account-button";
 
 export default async function SettingsPage() {
   const supabase = await createClient();
@@ -62,9 +63,9 @@ export default async function SettingsPage() {
         <p className="mt-2 text-sm text-gray-600">
           Once you delete your account, there is no going back.
         </p>
-        <button className="mt-4 rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50">
-          Delete Account
-        </button>
+        <div className="mt-4">
+          <DeleteAccountButton />
+        </div>
       </div>
     </div>
   );

--- a/src/components/delete-account-button.tsx
+++ b/src/components/delete-account-button.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useTransition } from "react";
+import { deleteAccount } from "@/app/(dashboard)/dashboard/settings/actions";
+import { Button } from "@/components/ui/button";
+import { Loader2, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+export function DeleteAccountButton() {
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = async () => {
+    const confirmed = window.confirm(
+      "Are you sure you want to delete your account? This action cannot be undone."
+    );
+
+    if (!confirmed) return;
+
+    startTransition(async () => {
+      try {
+        await deleteAccount();
+      } catch (error) {
+        console.error(error);
+        toast.error("Failed to delete account. Please try again.");
+      }
+    });
+  };
+
+  return (
+    <Button
+      variant="destructive"
+      onClick={handleDelete}
+      disabled={isPending}
+    >
+      {isPending ? (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          Deleting...
+        </>
+      ) : (
+        <>
+          <Trash2 className="mr-2 h-4 w-4" />
+          Delete Account
+        </>
+      )}
+    </Button>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,6 +9,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline:
           "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
         ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,4 +1,5 @@
 import { createServerClient } from "@supabase/ssr";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import { env } from "@/env";
 
@@ -23,6 +24,19 @@ export async function createClient() {
             // This can be ignored if you have middleware refreshing sessions.
           }
         },
+      },
+    }
+  );
+}
+
+export function createAdminClient() {
+  return createSupabaseClient(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.SUPABASE_SERVICE_ROLE_KEY,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
       },
     }
   );


### PR DESCRIPTION
Closes #23

## Changes
- **Server Action** (`settings/actions.ts`): `deleteAccount()` verifies auth, uses admin client to delete user from `auth.users`, redirects to login
- **Client Component** (`delete-account-button.tsx`): Confirmation dialog via `window.confirm()`, loading state with spinner, error toast
- **Admin Client** (`lib/supabase/server.ts`): New `createAdminClient()` using service role key for privileged operations
- **Button variant**: Added `destructive` variant to button component
- **Settings page**: Replaced placeholder button with functional `<DeleteAccountButton />`

## Security
- Auth check before deletion (getUser)
- Service role key used server-side only (never exposed to client)
- FK CASCADE handles profiles/projects cleanup automatically