### PR TITLE
refactor: enforce Stripe webhook secret validation (#24)

### DIFF
--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -10,7 +10,7 @@ export async function POST(request: Request) {
   const headersList = await headers();
   const signature = headersList.get("stripe-signature");
 
-  if (!signature || !env.STRIPE_WEBHOOK_SECRET) {
+  if (!signature) {
     return NextResponse.json({ error: "Missing signature" }, { status: 400 });
   }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,7 +5,7 @@ export const env = createEnv({
   server: {
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
     STRIPE_SECRET_KEY: z.string().min(1),
-    STRIPE_WEBHOOK_SECRET: z.string().optional(),
+    STRIPE_WEBHOOK_SECRET: z.string().min(1),
     STRIPE_PRO_PRICE_ID: z.string().min(1),
   },
   client: {


### PR DESCRIPTION
Closes #24

## Changes
- **`src/env.ts`**: Changed `STRIPE_WEBHOOK_SECRET` from `z.string().optional()` to `z.string().min(1)` — now required at build time
- **`src/app/api/stripe/webhook/route.ts`**: Removed redundant `!env.STRIPE_WEBHOOK_SECRET` check (env validation guarantees it exists)

This ensures missing webhook secrets are caught at deploy/build time rather than silently failing at runtime.