### PR TITLE
test: add unit tests for utils and stripe helpers (#25)

### DIFF
--- a/src/lib/stripe.test.ts
+++ b/src/lib/stripe.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock the env module BEFORE importing stripe
+vi.mock("@/env", () => ({
+  env: {
+    STRIPE_SECRET_KEY: "sk_test_mock",
+    STRIPE_PRO_PRICE_ID: "price_mock_pro_123",
+  },
+}));
+
+// Import the module under test
+import { PLANS } from "./stripe";
+
+describe("stripe helpers", () => {
+  describe("PLANS", () => {
+    it("exports PLANS correctly", () => {
+      expect(PLANS).toBeDefined();
+      expect(Object.keys(PLANS)).toContain("free");
+      expect(Object.keys(PLANS)).toContain("pro");
+    });
+
+    it("has correct configuration for Free plan", () => {
+      expect(PLANS.free.name).toBe("Free");
+      expect(PLANS.free.price).toBe(0);
+      expect(PLANS.free.priceId).toBeNull();
+    });
+
+    it("has correct configuration for Pro plan", () => {
+      expect(PLANS.pro.name).toBe("Pro");
+      expect(PLANS.pro.price).toBe(8);
+      // This should match the mocked value
+      expect(PLANS.pro.priceId).toBe("price_mock_pro_123");
+    });
+  });
+});

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { cn } from "./utils";
+
+describe("utils", () => {
+  describe("cn", () => {
+    it("merges class names correctly", () => {
+      expect(cn("foo", "bar")).toBe("foo bar");
+    });
+
+    it("handles conditional classes", () => {
+      expect(cn("foo", false && "bar", "baz")).toBe("foo baz");
+      expect(cn("foo", true && "bar", "baz")).toBe("foo bar baz");
+    });
+
+    it("resolves tailwind conflicts", () => {
+      expect(cn("p-4", "p-2")).toBe("p-2");
+      expect(cn("text-red-500", "text-blue-500")).toBe("text-blue-500");
+    });
+
+    it("handles empty/undefined/null values", () => {
+      expect(cn("", undefined, null, "foo")).toBe("foo");
+      expect(cn(undefined)).toBe("");
+    });
+
+    it("supports object syntax", () => {
+      expect(cn({ "text-red-500": true, "text-blue-500": false })).toBe("text-red-500");
+    });
+  });
+});


### PR DESCRIPTION
Closes #25

## Changes
- **`src/lib/utils.test.ts`** (5 tests): `cn()` utility — basic merging, conditional classes, Tailwind conflict resolution, null/undefined handling, object syntax
- **`src/lib/stripe.test.ts`** (3 tests): `PLANS` config — export structure, Free plan defaults, Pro plan config. `@/env` properly mocked for isolation.

All 9 tests pass alongside existing smoke tests.