### PR TITLE
feat: implement project creation with server action (#22)

### DIFF
--- a/src/app/(dashboard)/dashboard/actions.ts
+++ b/src/app/(dashboard)/dashboard/actions.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+const createProjectSchema = z.object({
+  name: z.string().min(1, "Project name is required"),
+});
+
+export async function createProject(formData: FormData) {
+  const data = Object.fromEntries(formData);
+  const parseResult = createProjectSchema.safeParse(data);
+
+  if (!parseResult.success) {
+    return { error: parseResult.error.flatten().fieldErrors.name?.[0] || "Invalid input" };
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "Unauthorized" };
+  }
+
+  const { error } = await supabase.from("projects").insert({
+    name: parseResult.data.name,
+    user_id: user.id,
+  });
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  revalidatePath("/dashboard");
+  return { success: true };
+}

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CreateProjectButton } from "@/components/create-project-button";
+import { redirect } from "next/navigation";
 
 export default async function DashboardPage() {
   const supabase = await createClient();
@@ -8,15 +9,27 @@ export default async function DashboardPage() {
     data: { user },
   } = await supabase.auth.getUser();
 
+  if (!user) {
+    redirect("/login");
+  }
+
   const { data: profile } = await supabase
     .from("profiles")
     .select("*")
-    .eq("id", user?.id)
+    .eq("id", user.id)
     .single();
+
+  const { data: projects } = await supabase
+    .from("projects")
+    .select("*")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
 
   const planLabel = profile?.plan
     ? profile.plan.charAt(0).toUpperCase() + profile.plan.slice(1)
     : "Free";
+
+  const projectCount = projects?.length ?? 0;
 
   return (
     <div>
@@ -27,20 +40,43 @@ export default async function DashboardPage() {
 
       {/* Stats Grid */}
       <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {/* TODO: Connect to real projects count when table exists */}
-        <StatCard title="Projects" value="0" description="Active projects" />
+        <StatCard title="Projects" value={String(projectCount)} description="Active projects" />
         <StatCard title="Usage" value="0%" description="Of your plan limit" />
         <StatCard title="Plan" value={planLabel} description="Upgrade anytime" />
       </div>
 
-      {/* Empty State */}
-      <div className="mt-12 rounded-xl border-2 border-dashed border-gray-300 p-12 text-center">
-        <h3 className="text-lg font-medium text-gray-900">No projects yet</h3>
-        <p className="mt-2 text-sm text-gray-600">
-          Get started by creating your first project.
-        </p>
-        <CreateProjectButton className="mt-6" />
-      </div>
+      {projectCount === 0 ? (
+        /* Empty State */
+        <div className="mt-12 rounded-xl border-2 border-dashed border-gray-300 p-12 text-center">
+          <h3 className="text-lg font-medium text-gray-900">No projects yet</h3>
+          <p className="mt-2 text-sm text-gray-600">
+            Get started by creating your first project.
+          </p>
+          <CreateProjectButton className="mt-6" />
+        </div>
+      ) : (
+        /* Projects List */
+        <div className="mt-12">
+            <div className="flex items-center justify-between">
+                 <h2 className="text-lg font-medium text-gray-900">Your Projects</h2>
+                 <CreateProjectButton />
+            </div>
+            <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {projects?.map((project) => (
+                    <Card key={project.id} className="hover:bg-gray-50 transition-colors">
+                        <CardHeader className="pb-2">
+                            <CardTitle className="text-base">{project.name}</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-xs text-muted-foreground">
+                                Created {new Date(project.created_at).toLocaleDateString()}
+                            </p>
+                        </CardContent>
+                    </Card>
+                ))}
+            </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/create-project-button.tsx
+++ b/src/components/create-project-button.tsx
@@ -1,23 +1,78 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { useState } from "react";
+import { Plus, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button, type ButtonProps } from "@/components/ui/button";
+import { createProject } from "@/app/(dashboard)/dashboard/actions";
 
 export function CreateProjectButton({ className, ...props }: ButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    const formData = new FormData(e.currentTarget);
+    
+    try {
+        const result = await createProject(formData);
+        if (result?.error) {
+            toast.error(result.error);
+        } else {
+            toast.success("Project created successfully");
+            setIsOpen(false);
+        }
+    } catch {
+        toast.error("Something went wrong");
+    } finally {
+        setLoading(false);
+    }
+  }
+
   return (
-    <Button
-      className={className}
-      onClick={() =>
-        toast("🚧 Coming soon!", {
-          description: "Project creation is under development.",
-        })
-      }
-      {...props}
-    >
-      <Plus className="size-4" />
-      Create Project
-    </Button>
+    <>
+      <Button
+        className={className}
+        onClick={() => setIsOpen(true)}
+        {...props}
+      >
+        <Plus className="size-4" />
+        Create Project
+      </Button>
+
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 animate-in fade-in zoom-in-95 duration-200">
+           <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-lg dark:bg-gray-900">
+             <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">Create New Project</h2>
+             <form onSubmit={handleSubmit} className="space-y-4">
+               <div>
+                 <label htmlFor="name" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                   Project Name
+                 </label>
+                 <input
+                   autoFocus
+                   name="name"
+                   id="name"
+                   required
+                   className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                   placeholder="My Awesome Project"
+                 />
+               </div>
+               <div className="flex justify-end gap-2">
+                 <Button type="button" variant="ghost" onClick={() => setIsOpen(false)} disabled={loading}>
+                   Cancel
+                 </Button>
+                 <Button type="submit" disabled={loading}>
+                   {loading && <Loader2 className="mr-2 size-4 animate-spin" />}
+                   Create
+                 </Button>
+               </div>
+             </form>
+           </div>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
Closes #22

## Changes
- **Server Action** (`dashboard/actions.ts`): `createProject` with Zod validation, auth check, Supabase insert, path revalidation
- **CreateProjectButton**: Replaced toast placeholder with modal (name input, loading state, error/success toasts)
- **Dashboard**: Fetches real projects, shows count in StatCard, conditional empty state vs project grid with cards

## Dependencies
Built on PR #28 (projects table schema, now merged).

## Note
Local `pnpm build` requires `STRIPE_WEBHOOK_SECRET` env var (required since PR #30). TypeScript check passes.